### PR TITLE
update: 添加暂存sql代码功能

### DIFF
--- a/src/components/SqlEditor.vue
+++ b/src/components/SqlEditor.vue
@@ -62,7 +62,10 @@ watchEffect(async () => {
   // 初始化 / 更新默认 SQL
   if (inputEditor.value) {
     //尝试去ls中读出暂存的sql代码 ####
-    var rowCode = readCode();
+    var rowCode;
+    if (isSaveCode.value) {
+      rowCode = readCode();
+    }
     if (!rowCode) {
       rowCode = "-- 请在此处输入 SQL\n" + level.value.defaultSQL;
     }

--- a/src/core/saveCode.ts
+++ b/src/core/saveCode.ts
@@ -1,0 +1,37 @@
+const codeStorage = "saveCode";
+const isSaveCodeStorage = "isSaveCode";
+
+export const saveCode = (code?: string) => {
+  // 保存代码
+  localStorage.setItem(codeStorage, code);
+}
+
+export const readCode = () => {
+  // 读取代码
+  return localStorage.getItem(codeStorage)
+}
+
+export const deleteCode = () => {
+  // 删除代码
+  localStorage.removeItem(codeStorage);
+}
+
+export const setIsSaveCode = (isSaveCode?: bool) => {
+  // 设置是否保存代码
+  localStorage.setItem(isSaveCodeStorage, isSaveCode);
+}
+
+export const getIsSaveCode = () => {
+  // 读取是否保存代码
+  if (localStorage.getItem(isSaveCodeStorage) == "true"){
+    return true;
+  } else if (localStorage.getItem(isSaveCodeStorage) == "false"){
+    return false;
+  }
+  return true; //因为默认是true，localStorage里没有的就是没有执行过更改状态的，所以没有执行过修改的一定是true（默认），所以返回true
+}
+
+export const deleteIsSaveCode = () => {
+  // 删除是否保存代码
+  localStorage.removeItem(isSaveCodeStorage);
+}


### PR DESCRIPTION
添加暂存sql代码功能

使用时发现代码老是变成初始的sql非常不方便，研究了一下源码，改了一下，使用localStorage，网页关闭不丢失

本人是第一次使用typescript，都是照葫芦画瓢，所以写的不规范，代码能跑，见谅。

我是不是配置有问题，这报错全篇报红，我用的vscode

![image](https://github.com/liyupi/sql-mother/assets/85735251/23b3f289-7651-4578-8676-02ab09e52c59)

本人只有14岁，写的肯定非常不好，希望指点，谢谢

部分思路参考：https://www.bilibili.com/video/BV18T4y1z7zb/?spm_id_from=333.999.0.0

最后十分感谢鱼皮开源此项目！！！！