### PR TITLE
add: 添加暂存sql功能

### DIFF
--- a/src/components/SqlEditor.vue
+++ b/src/components/SqlEditor.vue
@@ -7,6 +7,7 @@
       </a-button>
       <a-button @click="doFormat">格式化</a-button>
       <a-button @click="doReset">重置</a-button>
+      <a-switch v-model:checked="isSaveCode" @change="saveCodeChange" />暂存代码
     </a-space>
   </div>
 </template>
@@ -29,6 +30,13 @@ import { QueryExecResult } from "sql.js";
 // eslint-disable-next-line no-undef
 import IStandaloneCodeEditor = monaco.editor.IStandaloneCodeEditor;
 import { message } from "ant-design-vue";
+import {
+  saveCode,
+  readCode,
+  deleteCode,
+  setIsSaveCode,
+  getIsSaveCode,
+} from "../core/saveCode";
 
 (self as any).MonacoEnvironment = {
   getWorker(_: any, label: any) {
@@ -54,13 +62,20 @@ const { level, onSubmit } = toRefs(props);
 const inputEditor = ref<IStandaloneCodeEditor>();
 const editorRef = ref<HTMLElement>();
 const db = ref();
+const isSaveCode = ref(getIsSaveCode()); // 是否暂存代码
 
 watchEffect(async () => {
   // 初始化 / 更新默认 SQL
   if (inputEditor.value) {
-    toRaw(inputEditor.value).setValue(
-      "-- 请在此处输入 SQL\n" + level.value.defaultSQL
-    );
+    //尝试去ls中读出暂存的sql代码 ####
+    var rowCode;
+    if (isSaveCode.value) {
+      rowCode = readCode();
+    }
+    if (!rowCode) {
+      rowCode = "-- 请在此处输入 SQL\n" + level.value.defaultSQL;
+    }
+    toRaw(inputEditor.value).setValue(rowCode);
   }
   // 初始化 / 更新 DB
   db.value = await initDB(level.value.initSQL);
@@ -99,6 +114,10 @@ const doSubmit = () => {
   }
   const inputStr = toRaw(inputEditor.value).getValue();
   console.log("inputStr", inputStr);
+  // 把代码保存到ls ####
+  if (isSaveCode.value) {
+    saveCode(inputStr);
+  }
   try {
     const result = runSQL(db.value, inputStr);
     const answerResult = runSQL(db.value, level.value.answer);
@@ -108,6 +127,14 @@ const doSubmit = () => {
     message.error("语句错误，" + error.message);
     // 向外层传递结果
     onSubmit?.value(inputStr, [], [], error.message);
+  }
+};
+
+const saveCodeChange = () => {
+  setIsSaveCode(isSaveCode.value);
+  if (!isSaveCode.value) {
+    // 清除ls中的代码 ####
+    deleteCode();
   }
 };
 

--- a/src/core/saveCode.ts
+++ b/src/core/saveCode.ts
@@ -1,0 +1,41 @@
+const codeStorage = "saveCode";
+const isSaveCodeStorage = "isSaveCode";
+
+export const saveCode = (code: string) => {
+  // 保存代码
+  localStorage.setItem(codeStorage, code);
+};
+
+export const readCode = () => {
+  // 读取代码
+  return localStorage.getItem(codeStorage);
+};
+
+export const deleteCode = () => {
+  // 删除代码
+  localStorage.removeItem(codeStorage);
+};
+
+export const setIsSaveCode = (isSaveCode: boolean) => {
+  // 设置是否保存代码
+  if (isSaveCode) {
+    localStorage.setItem(isSaveCodeStorage, "true");
+    return;
+  }
+  localStorage.setItem(isSaveCodeStorage, "false");
+};
+
+export const getIsSaveCode = () => {
+  // 读取是否保存代码
+  if (localStorage.getItem(isSaveCodeStorage) == "true") {
+    return true;
+  } else if (localStorage.getItem(isSaveCodeStorage) == "false") {
+    return false;
+  }
+  return true; //因为默认是true，localStorage里没有的就是没有执行过更改状态的，所以没有执行过修改的一定是true（默认），所以返回true
+};
+
+export const deleteIsSaveCode = () => {
+  // 删除是否保存代码
+  localStorage.removeItem(isSaveCodeStorage);
+};


### PR DESCRIPTION
add: 添加暂存sql功能

在使用网站时，sql老是回到初始状态，我希望他可以保存，所以研究了一下源码，实现了

sql代码数据存在localStorage中，关闭页面不丢失

不过有一个问题，只有用户点击确定按钮之后代码才会保存，不过我觉得也没问题，用户点击确定代表用户写完代码了，再保存

回来我有时间研究一下，看看如何实现实时保存

由于本人第一次使用typescript，照葫芦画瓢写出来了，过了编辑器的的代码检查，应该没问题，

本人只有14岁，并没有专门学过这个，所以可能写的不是很好，希望大佬指点，感谢！

部分思路参考：https://www.bilibili.com/video/BV18T4y1z7zb/?spm_id_from=333.999.0.0

最后感谢鱼皮开源这个网站！