### PR TITLE
fix: 修复控制台疯狂警报

### DIFF
--- a/src/components/MdViewer.vue
+++ b/src/components/MdViewer.vue
@@ -14,7 +14,6 @@ const plugins = [gfm(), highlight()];
 
 interface Props {
   value: string;
-  handleChange: (val: string) => void;
 }
 
 const props = withDefaults(defineProps<Props>(), {


### PR DESCRIPTION
fix: 修复控制台疯狂警报

控制台疯狂报警

![image](https://github.com/liyupi/sql-mother/assets/85735251/705a1d6d-dfb9-4cfd-bbcd-143a63fafd05)

修复后

![image](https://github.com/liyupi/sql-mother/assets/85735251/11ccd666-db38-4099-bd6e-6955203b8f6d)

原因：src\components\MdViewer.vue 中多要了一个handleChange参数

我搜了一下，在这个文件中这个参数并未使用，所以就删除了