### PR TITLE
feat: 格式化高亮答案

### DIFF
--- a/src/pages/IndexPage.vue
+++ b/src/pages/IndexPage.vue
@@ -37,7 +37,7 @@
             />
           </a-collapse-panel>
           <a-collapse-panel key="answer" header="查看答案">
-            {{ level.answer }}
+            <pre v-html="highlightCode(format(level.answer))"></pre>
           </a-collapse-panel>
         </a-collapse>
       </a-col>
@@ -46,6 +46,8 @@
 </template>
 
 <script setup lang="ts">
+import hljs from 'highlight.js';
+import { format } from "sql-formatter";
 import SqlEditor from "../components/SqlEditor.vue";
 import QuestionBoard from "../components/QuestionBoard.vue";
 import SqlResult from "../components/SqlResult.vue";
@@ -99,6 +101,11 @@ const onSubmit = (
   errorMsgRef.value = errorMsg;
   resultStatus.value = checkResult(res, answerRes);
 };
+
+const highlightCode = (code: string) => {
+  return hljs.highlightAuto(code).value;
+};
+
 </script>
 
 <style>


### PR DESCRIPTION
后期答案较长的情况下没有代码高亮和格式化（主要是格式化）看起来很难受，所以增加了一下

<img width="886" alt="image" src="https://github.com/liyupi/sql-mother/assets/75521101/d16922dc-9551-4448-9143-fb82dca93567">
